### PR TITLE
UI Cleanup

### DIFF
--- a/cloudformation/prediction.template.json
+++ b/cloudformation/prediction.template.json
@@ -70,7 +70,7 @@
                         "PREDICTION_ID": { "Ref": "PredictionId" },
                         "TILE_ENDPOINT": { "Ref": "TileEndpoint" },
                         "PREDICTION_ENDPOINT": { "Fn::Join": ["", [
-                            "http://", { "Fn::GetAtt": ["PredELB", "DNSName"]}, "/v1/models/default/versions/001:predict"]
+                            "http://", { "Fn::GetAtt": ["PredELB", "DNSName"]}, "/v1/models/default/versions/001"]
                         ]},
                         "MLENABLER_ENDPOINT": { "Fn::ImportValue": { "Fn::Join": [ "-", [
                             { "Ref": "StackName" },

--- a/lambda/download_and_predict/base.py
+++ b/lambda/download_and_predict/base.py
@@ -30,6 +30,13 @@ class DownloadAndPredict(object):
         self.inferences = inferences
         self.mlenabler_endpoint = mlenabler_endpoint
         self.prediction_endpoint = prediction_endpoint
+        self.meta = {}
+
+    def get_meta(self):
+        r = requests.post(self.prediction_endpoint + "/metadata")
+        r.raise_for_status()
+
+        self.meta = r.json()
 
     @staticmethod
     def get_tiles(event: SQSEvent) -> List[Tile]:
@@ -83,7 +90,7 @@ class DownloadAndPredict(object):
         return (list(tile_indices), payload)
 
     def post_prediction(self, payload: str, tiles: List[Tile], prediction_id: str) -> List[Dict[str, Any]]:
-        r = requests.post(self.prediction_endpoint, data=payload)
+        r = requests.post(self.prediction_endpoint + ":predict", data=payload)
         r.raise_for_status()
 
         preds = r.json()["predictions"]

--- a/lambda/download_and_predict/handler.py
+++ b/lambda/download_and_predict/handler.py
@@ -30,6 +30,9 @@ def handler(event: SQSEvent, context: Dict[str, Any]) -> None:
         prediction_endpoint=prediction_endpoint
     )
 
+    # Get meta about model to determine model type (Classification vs Object Detection)
+    dap.get_meta()
+
     # get tiles from our SQS event
     tiles = dap.get_tiles(event)
 

--- a/web/src/components/Model.vue
+++ b/web/src/components/Model.vue
@@ -1,6 +1,8 @@
 <template>
     <div class="col col--12">
         <div class='col col--12 clearfix py6'>
+            <h2 @click='close' class='fl cursor-pointer txt-underline-on-hover'>Models</h2>
+            <h2 class='fl px6'>&gt;</h2>
             <h2 @click='mode = "model"' class='fl cursor-pointer txt-underline-on-hover' v-text='model.name + " - " + model.source'></h2>
 
             <button @click='close' class='btn fr round btn--stroke color-gray color-black-on-hover'>
@@ -15,7 +17,7 @@
                 <svg class='icon'><use href='#icon-pencil'/></svg>
             </button>
 
-            <button @click='refresh' class='btn fr round btn--stroke color-gray color-blue-on-hover mr12'>
+            <button v-if='mode === "model"' @click='refresh' class='btn fr round btn--stroke color-gray color-blue-on-hover mr12'>
                 <svg class='icon'><use href='#icon-refresh'/></svg>
             </button>
         </div>

--- a/web/src/components/Prediction.vue
+++ b/web/src/components/Prediction.vue
@@ -10,20 +10,19 @@
             <span class='fr mr6 bg-blue-faint bg-blue-on-hover color-white-on-hover color-blue inline-block px6 py3 round txt-xs txt-bold cursor-pointer' v-text='"id: " + prediction.predictionsId'/>
         </div>
         <div class='border border--gray-light round col col--12 px12 py12 clearfix'>
-            <div class='col col--12 border-b border--gray-light clearfix mb6'>
-                <div class="flex-parent-inline py3">
-                    <button @click='mode = "assets"' class="btn btn--pill btn--s btn--pill-hl round">Assets</button>
-                    <button @click='mode = "stack"' class="btn btn--pill btn--s btn--pill-hc round">Stack</button>
-                    <button @click='mode = "map"' class="btn btn--pill btn--s btn--pill-hr round">Map</button>
-                </div>
-
-                <div v-if='mode === "assets"' class="flex-parent-inline py3 fr">
-                    <button v-if='prediction.logLink' @click='logLink(prediction.logLink)' class='mr6 btn btn--s btn--stroke color-gray color-blue-on-hover round'><svg class='icon fl' style='margin-top: 4px;'><use href='#icon-link'/></svg>Build Log</button>
-                    <button v-if='prediction.dockerLink' @click='ecrLink(prediction.dockerLink)' class='btn btn--s btn--stroke color-gray color-blue-on-hover round'><svg class='icon fl' style='margin-top: 4px;'><use href='#icon-link'/></svg> ECR</button>
-                </div>
-            </div>
 
             <template v-if='mode === "assets"'>
+                <div class='col col--12 border-b border--gray-light clearfix mb6'>
+                    <PredictionHeader
+                        :mode='mode'
+                        v-on:mode='mode = $event'
+                    />
+
+                    <div class='fr'>
+                        <button v-if='prediction.logLink' @click='logLink(prediction.logLink)' class='mr6 btn btn--s btn--stroke color-gray color-blue-on-hover round'><svg class='icon fl' style='margin-top: 4px;'><use href='#icon-link'/></svg>Build Log</button>
+                        <button v-if='prediction.dockerLink' @click='ecrLink(prediction.dockerLink)' class='btn btn--s btn--stroke color-gray color-blue-on-hover round'><svg class='icon fl' style='margin-top: 4px;'><use href='#icon-link'/></svg> ECR</button>
+                    </div>
+                </div>
                 <template v-if='prediction.modelLink'>
                     <div class='col col--12 py3'>
                         <div class='align-center'>TF Model</div>
@@ -61,10 +60,21 @@
                         :model='model'
                         :imagery='imagery'
                         :prediction='prediction'
+                        v-on:mode='mode = $event'
                     />
                 </template>
             </template>
             <template v-else-if='mode === "map"'>
+                <div class='col col--12 border-b border--gray-light clearfix mb6'>
+                    <PredictionHeader
+                        :mode='mode'
+                        v-on:mode='mode = $event'
+                    />
+
+                    <div class='fr'>
+                        <!--Map Specific Actions-->
+                    </div>
+                </div>
                 <template v-if='tiles'>
                     <div class='align-center pb6'>Prediction Tiles</div>
 
@@ -88,6 +98,7 @@
 
 <script>
 import UploadPrediction from './UploadPrediction.vue';
+import PredictionHeader from './PredictionHeader.vue';
 import Stack from './Stack.vue';
 import Map from './Map.vue';
 
@@ -106,6 +117,7 @@ export default {
     components: {
         Map,
         Stack,
+        PredictionHeader,
         UploadPrediction
     },
     methods: {

--- a/web/src/components/Prediction.vue
+++ b/web/src/components/Prediction.vue
@@ -44,25 +44,12 @@
                 </template>
             </template>
             <template v-else-if='mode === "stack"'>
-                <template v-if='!prediction.modelLink'>
-                    <div class='col col--12 py6'>
-                        <div class='flex-parent flex-parent--center-main pt36'>
-                            <svg class='flex-child icon w60 h60 color--gray'><use href='#icon-info'/></svg>
-                        </div>
-
-                        <div class='flex-parent flex-parent--center-main pt12 pb36'>
-                            <h1 class='flex-child txt-h4 cursor-default'>A Model must be uploaded before a stack is created</h1>
-                        </div>
-                    </div>
-                </template>
-                <template v-else>
-                    <Stack
-                        :model='model'
-                        :imagery='imagery'
-                        :prediction='prediction'
-                        v-on:mode='mode = $event'
-                    />
-                </template>
+                <Stack
+                    :model='model'
+                    :imagery='imagery'
+                    :prediction='prediction'
+                    v-on:mode='mode = $event'
+                />
             </template>
             <template v-else-if='mode === "map"'>
                 <div class='col col--12 border-b border--gray-light clearfix mb6'>

--- a/web/src/components/PredictionHeader.vue
+++ b/web/src/components/PredictionHeader.vue
@@ -1,0 +1,26 @@
+<template>
+    <div class="flex-parent-inline py3">
+        <button @click='emit("assets")' :class='{
+            "btn--stroke": mode !== "assets"
+        }' class="btn btn--pill btn--pill-stroke btn--s btn--pill-hl round">Assets</button>
+        <button @click='emit("stack")' :class='{
+            "btn--stroke": mode !== "stack"
+        }' class="btn btn--pill btn--s btn--pill-hc btn--pill-stroke round">Stack</button>
+        <button @click='emit("map")' :class='{
+            "btn--stroke": mode !== "map"
+        }' class="btn btn--pill btn--s btn--pill-hr btn--pill-stroke round">Map</button>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'PredictionMap',
+    props: ['mode'],
+    methods: {
+        emit: function(mode) {
+            this.mode = mode;
+            this.$emit('mode', mode);
+        }
+    }
+}
+</script>

--- a/web/src/components/Stack.vue
+++ b/web/src/components/Stack.vue
@@ -1,13 +1,20 @@
 <template>
     <div class='col col--12 relative'>
-        <div class='absolute right top'>
-            <button @click='refresh' class='btn fr round btn--stroke btn--gray'>
-                <svg class='icon'><use href='#icon-refresh'/></svg>
-            </button>
+        <div class='col col--12 border-b border--gray-light clearfix mb6'>
+            <PredictionHeader
+                mode='stack'
+                v-on:mode='emitmode($event)'
+            />
 
-            <button v-if='complete.includes(stack.status)' @click='deleteStack' class='mr12 btn fr round btn--stroke color-gray color-red-on-hover'>
-                <svg class='icon'><use href='#icon-trash'/></svg>
-            </button>
+            <div class='fr'>
+                <button @click='refresh' class='btn fr round btn--stroke btn--gray'>
+                    <svg class='icon'><use href='#icon-refresh'/></svg>
+                </button>
+
+                <button v-if='complete.includes(stack.status)' @click='deleteStack' class='mr12 btn fr round btn--stroke color-gray color-red-on-hover'>
+                    <svg class='icon'><use href='#icon-trash'/></svg>
+                </button>
+            </div>
         </div>
 
         <template v-if='loading'>
@@ -79,6 +86,7 @@
 
 <script>
 import TileMap from './TileMap.vue';
+import PredictionHeader from './PredictionHeader.vue';
 
 export default {
     name: 'Stack',
@@ -180,6 +188,9 @@ export default {
                 if (!this.looping) this.loop();
             });
         },
+        emitmode: function(mode) {
+            this.$emit('mode', mode);
+        },
         createStack: function() {
             if (!this.image) return;
             if (!this.inferences) return;
@@ -206,6 +217,7 @@ export default {
         }
     },
     components: {
+        PredictionHeader,
         TileMap
     }
 }

--- a/web/src/components/Stack.vue
+++ b/web/src/components/Stack.vue
@@ -6,7 +6,7 @@
                 v-on:mode='emitmode($event)'
             />
 
-            <div class='fr'>
+            <div v-if='prediction.modelLink' class='fr'>
                 <button @click='refresh' class='btn fr round btn--stroke btn--gray'>
                     <svg class='icon'><use href='#icon-refresh'/></svg>
                 </button>
@@ -17,7 +17,18 @@
             </div>
         </div>
 
-        <template v-if='loading'>
+        <template v-if='!prediction.modelLink'>
+            <div class='col col--12 py6'>
+                <div class='flex-parent flex-parent--center-main pt36'>
+                    <svg class='flex-child icon w60 h60 color--gray'><use href='#icon-info'/></svg>
+                </div>
+
+                <div class='flex-parent flex-parent--center-main pt12 pb36'>
+                    <h1 class='flex-child txt-h4 cursor-default'>A Model must be uploaded before a stack is created</h1>
+                </div>
+            </div>
+        </template>
+        <template v-else-if='loading'>
             <div class='flex-parent flex-parent--center-main w-full py24'>
                 <div class='flex-child loading py24'></div>
             </div>


### PR DESCRIPTION
![Screenshot from 2020-04-01 13-07-16](https://user-images.githubusercontent.com/1297009/78181756-bb15e480-7419-11ea-8229-d76e25b57865.png)

- Add breadcrumbs to top bar for easier navigation
- Hide the model refresh button when not on model list page to avoid multiple refresh buttons on the page
- Prediction model tabs now highlight which pane you are on
- Prediction Lambda Function grabs TFServing metadata for future differentiation between object classification & object detection

cc/ @martham93 @geohacker 