### PR TITLE
Stack Helper

### DIFF
--- a/cloudformation/ml-enabler.template.js
+++ b/cloudformation/ml-enabler.template.js
@@ -218,6 +218,7 @@ const Resources = {
                         Action: [
                             'cloudformation:CreateStack',
                             'cloudformation:DeleteStack',
+                            'cloudformation:ListStacks',
                             'cloudformation:DescribeStacks',
                             'cloudformation:DescribeStackEvents',
                             'cloudformation:DescribeStackResources'

--- a/ml_enabler/__init__.py
+++ b/ml_enabler/__init__.py
@@ -30,7 +30,8 @@ def init_routes(app):
     from ml_enabler.api.ml import StatusCheckAPI, MLModelAPI, GetAllModels, \
         PredictionAPI, PredictionUploadAPI, PredictionTileAPI, MLModelTilesAPI, \
         MLModelTilesGeojsonAPI, GetAllPredictions, PredictionTileMVT, ImageryAPI, \
-        PredictionStackAPI, PredictionInfAPI, MapboxAPI, MetaAPI, PredictionExport
+        PredictionStackAPI, PredictionStacksAPI, PredictionInfAPI, MapboxAPI, MetaAPI, \
+        PredictionExport
     from ml_enabler.api.swagger import SwaggerDocsAPI
 
     api.add_resource(StatusCheckAPI,            '/')
@@ -40,6 +41,8 @@ def init_routes(app):
     api.add_resource(SwaggerDocsAPI,            '/v1/docs')
 
     api.add_resource(MapboxAPI,                 '/v1/mapbox', methods=['GET'])
+
+    api.add_resource(PredictionStacksAPI,        '/v1/stacks', methods=['GET'])
 
     api.add_resource(GetAllModels,              '/v1/model/all', methods=['GET'])
     api.add_resource(MLModelAPI,                '/v1/model', endpoint="post", methods=['POST'])

--- a/ml_enabler/models/ml_model.py
+++ b/ml_enabler/models/ml_model.py
@@ -1,10 +1,10 @@
 import mercantile
 from ml_enabler import db
-from ml_enabler.models.utils import timestamp, \
-     ST_GeomFromText, ST_Intersects, ST_MakeEnvelope
+from ml_enabler.models.utils import timestamp
 from ml_enabler.utils import bbox_to_polygon_wkt, geojson_to_bbox
 from geoalchemy2 import Geometry
-from geoalchemy2.functions import ST_Envelope, ST_AsGeoJSON, ST_Within
+from geoalchemy2.functions import ST_Envelope, ST_AsGeoJSON, ST_Within, \
+     ST_GeomFromText, ST_Intersects, ST_MakeEnvelope
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import func, text
 from sqlalchemy.sql.expression import cast

--- a/ml_enabler/models/utils.py
+++ b/ml_enabler/models/utils.py
@@ -1,7 +1,4 @@
 import datetime
-from geoalchemy2 import Geometry
-from geoalchemy2.functions import GenericFunction
-
 
 class NotFound(Exception):
     """ Custom exception to indicate model not found in database"""
@@ -25,26 +22,3 @@ def timestamp():
     timestamp when new models initialised"""
     return datetime.datetime.utcnow()
 
-
-class ST_GeomFromText(GenericFunction):
-    """ Export the postgis ST_GeomFromText function """
-    name = 'ST_GeomFromText'
-    type = Geometry
-
-
-class ST_Intersects(GenericFunction):
-    """ Exposes PostGIS ST_Intersects function """
-    name = 'ST_Intersects'
-    type = Geometry
-
-
-class ST_MakeEnvelope(GenericFunction):
-    """ Exposes PostGIS ST_MakeEnvelope function """
-    name = 'ST_MakeEnvelope'
-    type = Geometry
-
-
-class ST_AsText(GenericFunction):
-    """ Exposes PostGIS ST_AsText function """
-    name = 'ST_AsText'
-    type = Geometry

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -12,7 +12,7 @@
                     <button @click='mode = "editmodel"' class='btn fr round btn--stroke color-gray color-green-on-hover'>
                         <svg class='icon'><use href='#icon-plus'/></svg>
                     </button>
-                    <button @click='getModels' class='btn fr round btn--stroke color-gray color-blue-on-hover mr12'>
+                    <button @click='refresh' class='btn fr round btn--stroke color-gray color-blue-on-hover mr12'>
                         <svg class='icon'><use href='#icon-refresh'/></svg>
                     </button>
                 </div>
@@ -41,6 +41,10 @@
                                 <div class='col col--6'>
                                     <div @click.prevent.stop='external(model.projectUrl)' class='fr bg-blue-faint bg-blue-on-hover color-white-on-hover color-blue inline-block px6 py3 round txt-xs txt-bold cursor-pointer'>
                                         Project Page
+                                    </div>
+
+                                    <div v-if='stacks.models.includes(model.modelId)' class='fr bg-green-faint bg-green-on-hover color-white-on-hover color-green inline-block px6 py3 round txt-xs txt-bold mr3'>
+                                        Active Stack
                                     </div>
                                 </div>
                             </div>
@@ -73,6 +77,11 @@ export default {
     data: function() {
         return {
             mode: 'models',
+            stacks: {
+                models: [],
+                predictions: [],
+                stacks: []
+            },
             model: {
                 modelId: false,
                 name: '',
@@ -101,10 +110,14 @@ export default {
         }
     },
     mounted: function() {
-        this.getModels();
-        this.getMeta();
+        this.refresh();
     },
     methods: {
+        refresh: function() {
+            this.getModels();
+            this.getMeta();
+            this.getStacks();
+        },
         external: function(url) {
             if (!url) return;
 
@@ -132,6 +145,17 @@ export default {
                 this.meta = res;
             }).catch((err) => {
                 console.error(err);
+            });
+        },
+        getStacks: function() {
+            fetch(window.api + '/v1/stacks', {
+                method: 'GET'
+            }).then((res) => {
+                return res.json();
+            }).then((res) => {
+                if (!res.error) {
+                    this.stacks = res;
+                }
             });
         },
         getModels: function() {

--- a/web/src/components/Model.vue
+++ b/web/src/components/Model.vue
@@ -65,6 +65,9 @@
                                     <div v-if='pred.saveLink' class='fr mx3 bg-blue-faint bg-blue-on-hover color-white-on-hover color-blue inline-block px6 py3 round txt-xs txt-bold cursor-pointer'>
                                         Container
                                     </div>
+                                    <div v-if='stacks.predictions.includes(pred.predictionsId)' class='fr bg-green-faint bg-green-on-hover color-white-on-hover color-green inline-block px6 py3 round txt-xs txt-bold mr3'>
+                                        Active Stack
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -140,6 +143,11 @@ export default {
                 version: '',
                 tileZoom: 18,
                 bbox: [-180.0, -90.0, 180.0, 90.0]
+            },
+            stacks: {
+                models: [],
+                predictions: [],
+                names: []
             }
         }
     },
@@ -167,6 +175,7 @@ export default {
 
             this.getPredictions();
             this.getImagery();
+            this.getStacks();
         },
         close: function() {
             this.$emit('close');
@@ -210,6 +219,17 @@ export default {
                     this.predictions = vSort.desc(res.map(r => r.versionString)).map(r => {
                         return vMap[r];
                     });
+                }
+            });
+        },
+        getStacks: function() {
+            fetch(window.api + '/v1/stacks', {
+                method: 'GET'
+            }).then((res) => {
+                return res.json();
+            }).then((res) => {
+                if (!res.error) {
+                    this.stacks = res;
                 }
             });
         },


### PR DESCRIPTION
Adds even better management for stacks. Previously there was no way to determine what stacks were running from the UI outside of manually checking every prediction page manually.

### Actions
- Add`Active Stack` tag to a model where 1 or more predictions has a stack
- Add `Active Stack` tag to prediction on model page that has a stack
- Add `cloudformation:ListStacks` perm
- Add StacksList API

![Screenshot from 2020-06-01 15-36-02](https://user-images.githubusercontent.com/1297009/83461615-0c445380-a41e-11ea-9044-7c65a83ded50.png)
![Screenshot from 2020-06-01 15-35-55](https://user-images.githubusercontent.com/1297009/83461617-0cdcea00-a41e-11ea-9717-1afd6107053e.png)


cc/ @martham93 @geohacker 