### PR TITLE
Prediction Router

### DIFF
--- a/ml_enabler/__init__.py
+++ b/ml_enabler/__init__.py
@@ -31,7 +31,7 @@ def init_routes(app):
         PredictionAPI, PredictionUploadAPI, PredictionTileAPI, MLModelTilesAPI, \
         MLModelTilesGeojsonAPI, GetAllPredictions, PredictionTileMVT, ImageryAPI, \
         PredictionStackAPI, PredictionStacksAPI, PredictionInfAPI, MapboxAPI, MetaAPI, \
-        PredictionExport
+        PredictionExport, PredictionSingleAPI
     from ml_enabler.api.swagger import SwaggerDocsAPI
 
     api.add_resource(StatusCheckAPI,            '/')
@@ -58,6 +58,7 @@ def init_routes(app):
 
     api.add_resource(PredictionAPI,             '/v1/model/<int:model_id>/prediction', methods=['POST', 'GET'])
     api.add_resource(GetAllPredictions,         '/v1/model/<int:model_id>/prediction/all', methods=['GET'])
+    api.add_resource(PredictionSingleAPI,       '/v1/model/<int:model_id>/prediction/<int:prediction_id>', methods=['GET'])
     api.add_resource(PredictionAPI,             '/v1/model/<int:model_id>/prediction/<int:prediction_id>', endpoint="patch", methods=['PATCH'])
     api.add_resource(PredictionUploadAPI,       '/v1/model/<int:model_id>/prediction/<int:prediction_id>/upload', methods=['POST'])
     api.add_resource(PredictionStackAPI,        '/v1/model/<int:model_id>/prediction/<int:prediction_id>/stack', methods=['GET', 'POST', 'DELETE'])

--- a/ml_enabler/api/ml.py
+++ b/ml_enabler/api/ml.py
@@ -1001,6 +1001,13 @@ class PredictionUploadAPI(Resource):
                 "error": "model exists"
             }, 400
 
+class PredictionSingleAPI(Resource):
+    def get(self, model_id, prediction_id):
+        prediction = PredictionService.get_prediction_json(prediction_id)
+
+        return prediction, 400
+
+
 class PredictionAPI(Resource):
     """ Methods to manage ML predictions """
 

--- a/ml_enabler/api/ml.py
+++ b/ml_enabler/api/ml.py
@@ -10,6 +10,7 @@ from flask import Response
 from ml_enabler.models.dtos.ml_model_dto import MLModelDTO, MLModelVersionDTO, PredictionDTO
 from schematics.exceptions import DataError
 from ml_enabler.services.ml_model_service import MLModelService, MLModelVersionService
+from ml_enabler.models.ml_model import MLModelVersion
 from ml_enabler.services.prediction_service import PredictionService, PredictionTileService
 from ml_enabler.services.imagery_service import ImageryService
 from ml_enabler.models.utils import NotFound, VersionNotFound, \
@@ -1003,9 +1004,23 @@ class PredictionUploadAPI(Resource):
 
 class PredictionSingleAPI(Resource):
     def get(self, model_id, prediction_id):
-        prediction = PredictionService.get_prediction_json(prediction_id)
+        prediction = PredictionService.get_prediction_by_id(prediction_id)
+        version = MLModelVersion.get(prediction.version_id)
 
-        return prediction, 400
+        pred = {
+            "predictionsId": prediction.id,
+            "modelId": prediction.model_id,
+            "versionId": prediction.version_id,
+            "versionString": f'{version.version_major}.{version.version_minor}.{version.version_patch}',
+            "dockerUrl": prediction.docker_url,
+            "tileZoom": prediction.tile_zoom,
+            "logLink": prediction.log_link,
+            "modelLink": prediction.model_link,
+            "dockerLink": prediction.docker_link,
+            "saveLink": prediction.save_link
+        }
+
+        return pred, 400
 
 
 class PredictionAPI(Resource):

--- a/ml_enabler/services/prediction_service.py
+++ b/ml_enabler/services/prediction_service.py
@@ -70,20 +70,6 @@ class PredictionService():
             raise NotFound('Prediction does not exist')
 
     @staticmethod
-    def get_prediction_json(prediction_id: int):
-        """
-        Get a JSON representation of a prediction
-        :params prediction_id
-        """
-
-        prediction = Prediction.get(prediction_id)
-
-        if prediction:
-            return prediction.as_dto()
-        else:
-            raise PredictionsNotFound
-
-    @staticmethod
     def get_prediction_by_id(prediction_id: int):
         """
         Get a prediction by ID

--- a/ml_enabler/services/prediction_service.py
+++ b/ml_enabler/services/prediction_service.py
@@ -70,6 +70,20 @@ class PredictionService():
             raise NotFound('Prediction does not exist')
 
     @staticmethod
+    def get_prediction_json(prediction_id: int):
+        """
+        Get a JSON representation of a prediction
+        :params prediction_id
+        """
+
+        prediction = Prediction.get(prediction_id)
+
+        if prediction:
+            return prediction.as_dto()
+        else:
+            raise PredictionsNotFound
+
+    @staticmethod
     def get_prediction_by_id(prediction_id: int):
         """
         Get a prediction by ID

--- a/web/src/components/Model.vue
+++ b/web/src/components/Model.vue
@@ -44,7 +44,10 @@
                         </div>
                     </template>
                     <template v-else>
-                        <div :key='pred.predictionsId' v-for='pred in predictions' @click='showPrediction(pred)' class='cursor-pointer col col--12'>
+                        <div :key='pred.predictionsId' v-for='pred in predictions' @click='$router.push({ name: "prediction", params: {
+                            modelid: $route.params.modelid,
+                            predid: pred.predictionsId
+                        }})' class='cursor-pointer col col--12'>
                             <div class='col col--12 grid py6 px12 bg-darken10-on-hover'>
                                 <div class='col col--6'>
                                     <div class='col col--12 clearfix'>
@@ -109,24 +112,14 @@
             <template v-else-if='mode === "editPrediction"'>
                 <CreatePrediction :modelid='model.modelId' v-on:close='refresh' />
             </template>
-            <template v-else-if='mode === "showPrediction"'>
-                <Prediction
-                    :meta='meta'
-                    :imagery='imagery'
-                    :model='model'
-                    :prediction='prediction'
-                    v-on:close='refresh'
-                />
-            </template>
         </div>
     </div>
 </template>
 
 <script>
 import vSort from 'semver-sort';
-import Prediction from './Prediction.vue';
-import CreatePrediction from './CreatePrediction.vue';
 import Imagery from './Imagery.vue';
+import CreatePrediction from './CreatePrediction.vue';
 
 export default {
     name: 'Model',
@@ -158,7 +151,6 @@ export default {
     },
     components: {
         Imagery,
-        Prediction,
         CreatePrediction
     },
     mounted: function() {
@@ -174,10 +166,6 @@ export default {
         },
         close: function() {
             this.$emit('close');
-        },
-        showPrediction: function(pred) {
-            this.prediction = pred;
-            this.mode = 'showPrediction';
         },
         external: function(url) {
             if (!url) return;

--- a/web/src/components/Prediction.vue
+++ b/web/src/components/Prediction.vue
@@ -141,6 +141,7 @@ export default {
         },
         refresh: function() {
             this.getTilejson();
+            this.getPrediction();
         },
         getPrediction: function() {
             fetch(window.api + `/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}`, {

--- a/web/src/components/Prediction.vue
+++ b/web/src/components/Prediction.vue
@@ -3,7 +3,7 @@
         <div class='col col--12 clearfix py6'>
             <h2 class='fl cursor-default' v-text='"Prediction: " + prediction.versionString'></h2>
 
-            <button @click='close' class='btn fr round btn--stroke color-gray color-black-on-hover'>
+            <button @click='$router.push({ name: "model", params: { modelid: $route.params.modelid } })' class='btn fr round btn--stroke color-gray color-black-on-hover'>
                 <svg class='icon'><use href='#icon-close'/></svg>
             </button>
 
@@ -48,14 +48,12 @@
                 <template v-else>
                     <div class='align-center pb6'>Upload a model to get started</div>
 
-                    <UploadPrediction :prediction='prediction' v-on:close='close'/>
+                    <UploadPrediction :prediction='prediction' v-on:close='$router.push({ name: "model", params: { modelid: $route.params.modelid } })'/>
                 </template>
             </template>
             <template v-else-if='mode === "stack"'>
                 <Stack
                     :meta='meta'
-                    :model='model'
-                    :imagery='imagery'
                     :prediction='prediction'
                     v-on:mode='mode = $event'
                 />
@@ -74,7 +72,7 @@
                 <template v-if='tiles'>
                     <div class='align-center pb6'>Prediction Tiles</div>
 
-                    <Map :model='model' :prediction='prediction' :tilejson='tiles'/>
+                    <Map :prediction='prediction' :tilejson='tiles'/>
                 </template>
                 <template v-else>
                     <div class='col col--12 py6'>
@@ -91,7 +89,6 @@
             <template v-else-if='mode === "export"'>
                 <Export
                     :meta='meta'
-                    :model='model'
                     :prediction='prediction'
                     :tilejson='tiles'
                     v-on:mode='mode = $event'
@@ -102,18 +99,19 @@
 </template>
 
 <script>
-import UploadPrediction from './UploadPrediction.vue';
+import UploadPrediction from './prediction/UploadPrediction.vue';
 import PredictionHeader from './PredictionHeader.vue';
-import Export from './Export.vue';
-import Stack from './Stack.vue';
-import Map from './Map.vue';
+import Export from './prediction/Export.vue';
+import Stack from './prediction/Stack.vue';
+import Map from './prediction/Map.vue';
 
 export default {
     name: 'Prediction',
-    props: ['meta', 'imagery', 'model', 'prediction'],
+    props: ['meta'],
     data: function() {
         return {
             mode: 'assets',
+            prediction: {},
             tiles: false
         }
     },
@@ -128,9 +126,6 @@ export default {
         UploadPrediction
     },
     methods: {
-        close: function() {
-            this.$emit('close');
-        },
         ecrLink(ecr) {
             const url = `https://console.aws.amazon.com/ecr/repositories/${ecr.split(':')[0]}/`;
             this.external(url);
@@ -147,8 +142,17 @@ export default {
         refresh: function() {
             this.getTilejson();
         },
+        getPrediction: function() {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}`, {
+                method: 'GET'
+            }).then((res) => {
+                return res.json();
+            }).then((res) => {
+                this.prediction = res;
+            });
+        },
         getTilejson: function() {
-            fetch(window.api + `/v1/model/${this.model.modelId}/prediction/${this.prediction.predictionsId}/tiles`, {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}/tiles`, {
                 method: 'GET',
                 credentials: 'same-origin'
             }).then((res) => {

--- a/web/src/components/prediction/Export.vue
+++ b/web/src/components/prediction/Export.vue
@@ -64,11 +64,11 @@
 </template>
 
 <script>
-import PredictionHeader from './PredictionHeader.vue';
+import PredictionHeader from './../PredictionHeader.vue';
 
 export default {
     name: 'Export',
-    props: ['meta', 'model', 'prediction', 'tilejson'],
+    props: ['meta', 'tilejson'],
     data: function() {
         return {
             loading: false,
@@ -81,7 +81,7 @@ export default {
     },
     methods: {
         getExport: function() {
-            const url = new URL(`${window.location.origin}${window.api}/v1/model/${this.model.modelId}/prediction/${this.prediction.predictionsId}/export`);
+            const url = new URL(`${window.location.origin}${window.api}/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}/export`);
 
             url.searchParams.set('format', this.params.format);
             url.searchParams.set('inferences', this.params.inferences);

--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -95,12 +95,12 @@
 </template>
 
 <script>
-import buffer from '../../node_modules/@turf/buffer/index.js';
-import bboxPolygon from '../../node_modules/@turf/bbox-polygon/index.js';
+import buffer from '../../../node_modules/@turf/buffer/index.js';
+import bboxPolygon from '../../../node_modules/@turf/bbox-polygon/index.js';
 
 export default {
     name: 'Map',
-    props: ['model', 'prediction', 'tilejson'],
+    props: ['prediction', 'tilejson'],
     data: function() {
         return {
             bg: 'default',
@@ -304,7 +304,7 @@ export default {
             }
         },
         getImagery: function() {
-            fetch(window.api + `/v1/model/${this.model.modelId}/imagery`, {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/imagery`, {
                 method: 'GET'
             }).then((res) => {
                 return res.json();

--- a/web/src/components/prediction/Stack.vue
+++ b/web/src/components/prediction/Stack.vue
@@ -205,11 +205,11 @@
 
 <script>
 import TileMap from './TileMap.vue';
-import PredictionHeader from './PredictionHeader.vue';
+import PredictionHeader from './../PredictionHeader.vue';
 
 export default {
     name: 'Stack',
-    props: ['meta', 'model', 'prediction', 'imagery'],
+    props: ['meta', 'prediction'],
     data: function() {
         return {
             advanced: false,
@@ -228,6 +228,7 @@ export default {
             },
             looping: false,
             tagit: 0,
+            imagery: [],
             params: {
                 type: 'classification',
                 image: false,
@@ -269,11 +270,12 @@ export default {
         refresh: function() {
             this.getStatus();
             this.getQueue();
+            this.getImagery();
         },
         purgeQueue: function() {
             this.loading.queue = true;
 
-            fetch(window.api + `/v1/model/${this.model.modelId}/prediction/${this.prediction.predictionsId}/stack/tiles`, {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}/stack/tiles`, {
                 method: 'DELETE'
             }).then(() => {
                 this.getQueue();
@@ -282,7 +284,7 @@ export default {
         getQueue: function() {
             this.loading.queue = true;
 
-            fetch(window.api + `/v1/model/${this.model.modelId}/prediction/${this.prediction.predictionsId}/stack/tiles`, {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}/stack/tiles`, {
                 method: 'GET'
             }).then((res) => {
                 return res.json();
@@ -294,7 +296,7 @@ export default {
         postQueue: function(geojson) {
             this.loading.stack = true;
 
-            fetch(window.api + `/v1/model/${this.model.modelId}/prediction/${this.prediction.predictionsId}/stack/tiles`, {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}/stack/tiles`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -338,7 +340,7 @@ export default {
         getStatus: function() {
             this.loading.stack = true;
 
-            fetch(window.api + `/v1/model/${this.model.modelId}/prediction/${this.prediction.predictionsId}/stack`, {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}/stack`, {
                 method: 'GET'
             }).then((res) => {
                 return res.json();
@@ -352,7 +354,7 @@ export default {
         deleteStack: function() {
             this.loading.stack = true;
 
-            fetch(window.api + `/v1/model/${this.model.modelId}/prediction/${this.prediction.predictionsId}/stack`, {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}/stack`, {
                 method: 'DELETE'
             }).then((res) => {
                 return res.json();
@@ -361,6 +363,17 @@ export default {
                 this.loading.stack = false;
 
                 if (!this.looping) this.loop();
+            });
+        },
+        getImagery: function() {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/imagery`, {
+                method: 'GET'
+            }).then((res) => {
+                return res.json();
+            }).then((res) => {
+                this.imagery = res;
+            }).catch((err) => {
+                alert(err);
             });
         },
         emitmode: function(mode) {
@@ -372,7 +385,7 @@ export default {
 
             this.loading.stack = true;
 
-            fetch(window.api + `/v1/model/${this.model.modelId}/prediction/${this.prediction.predictionsId}/stack`, {
+            fetch(window.api + `/v1/model/${this.$route.params.modelid}/prediction/${this.$route.params.predid}/stack`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/web/src/components/prediction/Stack.vue
+++ b/web/src/components/prediction/Stack.vue
@@ -260,10 +260,6 @@ export default {
         }
     },
     mounted: function() {
-        if (this.imagery.length === 1) {
-            this.params.image = this.imagery[0];
-        }
-
         this.refresh();
     },
     methods: {
@@ -372,6 +368,10 @@ export default {
                 return res.json();
             }).then((res) => {
                 this.imagery = res;
+
+                if (this.imagery.length === 1) {
+                    this.params.image = this.imagery[0];
+                }
             }).catch((err) => {
                 alert(err);
             });

--- a/web/src/components/prediction/TileMap.vue
+++ b/web/src/components/prediction/TileMap.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script>
-import bboxPolygon from '../../node_modules/@turf/bbox-polygon/index.js';
+import bboxPolygon from '../../../node_modules/@turf/bbox-polygon/index.js';
 
 export default {
     name: 'TileMap',

--- a/web/src/components/prediction/UploadPrediction.vue
+++ b/web/src/components/prediction/UploadPrediction.vue
@@ -1,0 +1,52 @@
+<template>
+    <div class="col col--12">
+        <div class='col col--12'>
+            <file-pond
+                name='model-upload'
+                ref='pond'
+                label-idle='Drop model.zip here'
+                v-bind:allow-multiple='false'
+                v-on:processfile='uploaded'
+                accepted-file-types='application/zip'
+                allowRevert='false'
+                :server='`/v1/model/${route.params.modelid}/prediction/${route.params.predid}/upload`'
+                v-bind:files='files'
+            />
+        </div>
+
+        <div v-if='done' class='col col--12 py12'>
+            <button @click='close' class='btn btn--stroke round fr color-blue-light color-blue-on-hover'>Done</button>
+        </div>
+    </div>
+</template>
+
+<script>
+import vueFilePond from 'vue-filepond';
+import 'filepond/dist/filepond.min.css';
+import FilePondPluginFileValidateType from 'filepond-plugin-file-validate-type';
+const FilePond = vueFilePond(FilePondPluginFileValidateType);
+
+export default {
+    name: 'UploadPrediction',
+    props: ['prediction'],
+    components: {
+        FilePond
+    },
+    data: function() {
+        return {
+            done: false,
+            files: []
+        };
+    },
+    methods: {
+        uploaded: function(err) {
+            if (err) return;
+
+            this.done = true;
+        },
+        close: function() {
+            this.$emit('close');
+        }
+    }
+}
+</script>

--- a/web/src/components/prediction/UploadPrediction.vue
+++ b/web/src/components/prediction/UploadPrediction.vue
@@ -9,7 +9,7 @@
                 v-on:processfile='uploaded'
                 accepted-file-types='application/zip'
                 allowRevert='false'
-                :server='`/v1/model/${route.params.modelid}/prediction/${route.params.predid}/upload`'
+                :server='`/v1/model/${$route.params.modelid}/prediction/${$route.params.predid}/upload`'
                 v-bind:files='files'
             />
         </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -20,7 +20,7 @@ const router = new VueRouter({
         { path: '/model/:modelid', name: 'model', component: Model },
         { path: '/model/:modelid/edit', name: 'editmodel', component: EditModel },
 
-        { path: '/model/:modelid/prediction/:prediction', name: 'prediction', component: Prediction },
+        { path: '/model/:modelid/prediction/:predid', name: 'prediction', component: Prediction },
     ]
 });
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6,6 +6,7 @@ import App from './App.vue'
 import Home from './components/Home.vue';
 import Model from './components/Model.vue';
 import EditModel from './components/EditModel.vue';
+import Prediction from './components/Prediction.vue';
 
 Vue.use(VueRouter);
 Vue.config.productionTip = false
@@ -14,9 +15,12 @@ const router = new VueRouter({
     mode: 'hash',
     routes: [
         { path: '/', name: 'home', component: Home },
+
         { path: '/model/new', name: 'newmodel', component: EditModel },
         { path: '/model/:modelid', name: 'model', component: Model },
-        { path: '/model/:modelid/edit', name: 'editmodel', component: EditModel }
+        { path: '/model/:modelid/edit', name: 'editmodel', component: EditModel },
+
+        { path: '/model/:modelid/prediction/:prediction', name: 'prediction', component: Prediction },
     ]
 });
 


### PR DESCRIPTION
- Add additional API logic to support router based predictions
- Add prediction paths `/model/1/prediction/1`
- Refactor UI to use ids from router

cc/ @martham93 @geohacker 