### PR TITLE
Retraining Model Training

### DIFF
--- a/task-retrain/Dockerfile
+++ b/task-retrain/Dockerfile
@@ -1,4 +1,5 @@
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.0.2-gpu-py36-cu100-ubuntu18.04
+#FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.0.2-gpu-py36-cu100-ubuntu18.04
+FROM tensorflow/tensorflow:2.1.0-gpu-py3
 
 ENV SHELL /bin/bash
 ENV HOME=/home/task

--- a/task-retrain/Dockerfile
+++ b/task-retrain/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.1.0-gpu-py3
+FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.0.2-gpu-py36-cu100-ubuntu18.04
 
 ENV SHELL /bin/bash
 ENV HOME=/home/task
@@ -6,6 +6,11 @@ WORKDIR $HOME
 
 COPY ./ $HOME/retrain
 WORKDIR $HOME/retrain
+
+RUN mkdir /ml
+RUN mkdir /ml/models
+RUN mkdir /ml/data
+
 
 RUN apt-get update \
     && apt-get install -y git curl

--- a/task-retrain/model.py
+++ b/task-retrain/model.py
@@ -37,8 +37,8 @@ FLAGS = flags.FLAGS
 flags.DEFINE_integer('n_classes', 2, 'Number of classes in dataset')
 flags.DEFINE_list('class_names', ['not_industrial', 'industrial'],
                   'class names in data set')
-flags.DEFINE_integer('n_train_samps', None, 'number of samples in training set')
-flags.DEFINE_integer('n_val_samps', None, 'number of samples in validation set')
+flags.DEFINE_integer('n_train_samps', 400, 'number of samples in training set')
+flags.DEFINE_integer('n_val_samps', 100, 'number of samples in validation set')
 flags.DEFINE_list('x_feature_shape', [-1, 256, 256, 3], 'x feature shape')
 flags.DEFINE_string('x_feature_name', 'input_1', 'layer name')
 

--- a/task-retrain/model.py
+++ b/task-retrain/model.py
@@ -1,0 +1,391 @@
+"""
+Script specifying TF estimator object for training/serving
+@author: DevelopmentSeed
+"""
+
+import os
+import os.path as op
+import json
+import numpy as np
+import pandas as pd
+
+import zipfile
+
+from functools import partial
+
+from absl import app, flags, logging
+
+from tqdm import tqdm
+
+import tensorflow as tf
+from tensorflow.keras.models import Model
+from tensorflow.keras.applications import ResNet50, Xception
+from tensorflow.keras.layers import Dense, Dropout
+from tensorflow.keras.estimator import model_to_estimator
+from tensorflow.keras.optimizers import Adam, SGD, RMSprop
+
+from utils_train import FBetaScore
+from utils_readtfrecords import parse_and_augment_fn, parse_fn, get_dataset_feeder
+from utils_loss import sigmoid_focal_crossentropy
+import glob
+
+from sklearn.metrics import precision_score, recall_score, fbeta_score
+
+FLAGS = flags.FLAGS
+
+#overwrite these flags when calling model.py 
+flags.DEFINE_integer('n_classes', 2, 'Number of classes in dataset')
+flags.DEFINE_list('class_names', ['not_industrial', 'industrial'],
+                  'class names in data set')
+flags.DEFINE_integer('n_train_samps', None, 'number of samples in training set')
+flags.DEFINE_integer('n_val_samps', None, 'number of samples in validation set')
+flags.DEFINE_list('x_feature_shape', [-1, 256, 256, 3], 'x feature shape')
+flags.DEFINE_string('x_feature_name', 'input_1', 'layer name')
+
+flags.DEFINE_integer('cycle_length', 1, 'cycle length')
+flags.DEFINE_integer('n_map_threads', 4, 'threads')
+flags.DEFINE_integer('shuffle_buffer_size', None, 'should match size of train dataset')
+flags.DEFINE_integer('prefetch_buffer_size', 1, 'prefetch buffer size')
+
+flags.DEFINE_string('tf_train_data_dir', '/ml/data',
+                    'Path to data dir on GCS.')
+flags.DEFINE_string('tf_val_data_dir', '/ml/data', 'Path to data dir')
+flags.DEFINE_string('tf_test_data_dir', None, 'Path to data dir')
+
+flags.DEFINE_string('tf_model_dir', '/ml/models/', 'Path or GCS directory to save models.')
+flags.DEFINE_string('tf_test_results_dir', None, 'Path to GCS to write results')
+flags.DEFINE_string('model_id', 'a', 'model id for saving')
+
+flags.DEFINE_string('tf_test_ckpt_path', None, 'Use to override training and run prediction on test data.')
+
+flags.DEFINE_integer('tf_steps_per_summary', 10, 'Training steps per Tensorboard events save.')
+flags.DEFINE_integer('tf_steps_per_checkpoint', 100, 'Training steps per model checkpoint save.')
+flags.DEFINE_integer('tf_batch_size', 16, 'Size of one batch for training')
+flags.DEFINE_integer('tf_train_steps', 200, 'The number of training steps to perform')
+
+flags.DEFINE_integer('tf_dense_size_a', 256, 'Size of final dense hidden layer')
+flags.DEFINE_float('tf_dense_dropout_rate_a', 0.3, 'Dropout rate of the final dense hidden layer')
+flags.DEFINE_integer('tf_dense_size', 128, 'Size of final dense hidden layer')
+flags.DEFINE_float('tf_dense_dropout_rate', 0.35, 'Dropout rate of the final dense hidden layer')
+flags.DEFINE_string('tf_dense_activation', 'relu', 'Activation output layer')
+flags.DEFINE_float('tf_learning_rate', 0.001, 'learning rate for training')
+flags.DEFINE_string('tf_optimizer', 'adam', 'Optimizer function')
+
+
+######################
+# Modeling Code
+######################
+def resnet50_estimator(params, model_dir, run_config):
+    """Get a Resnet50 model as a tf.estimator object"""
+
+    # Get the original resnet model pre-initialized weights
+    base_model = Xception(weights='imagenet',
+                          include_top=False,  # Peel off top layer
+                          pooling='avg',
+                          input_shape=params['input_shape'])
+    # Get final layer of base Resnet50 model
+    x = base_model.output
+    # Add a fully-connected layer
+    x = Dense(params['dense_size_a'],
+              activation=params['dense_activation'],
+              name='dense')(x)
+    # Add (optional) dropout and output layer
+    x = Dropout(rate=params['dense_dropout_rate_a'])(x)
+    x = Dense(params['dense_size'],
+              activation=params['dense_activation'],
+              name='dense_preoutput')(x)
+    x = Dropout(rate=params['dense_dropout_rate'])(x)
+    output = Dense(params['n_classes'], name='output', activation='sigmoid')(x)
+
+    model = Model(inputs=base_model.input, outputs=output)
+
+    # Get (potentially decaying) learning rate
+    optimizer = get_optimizer(params['optimizer'], params['learning_rate'])
+    model.compile(optimizer=optimizer,
+                  loss=params['loss'], metrics=params['metrics'])
+
+    # Return estimator
+    m_e = model_to_estimator(keras_model=model, model_dir=model_dir + FLAGS.model_id,
+                             config=run_config)
+    return m_e
+
+
+def get_optimizer(opt_name, lr, momentum=0.9):
+    """Helper to get optimizer from text params"""
+    if opt_name == 'adam':
+        return Adam(learning_rate=lr)
+    if opt_name == 'sgd':
+        return SGD(learning_rate=lr)
+    if opt_name == 'rmsprop':
+        return RMSprop(learning_rate=lr, momentum=momentum)
+    raise ValueError('`opt_name`: {} not understood.'.format(opt_name))
+
+
+def resnet_serving_input_receiver_fn():
+    """Convert b64 string encoded images into a tensor for production"""
+    def decode_and_resize(image_str_tensor):
+        """Decodes image string, resizes it and returns a uint8 tensor."""
+        image = tf.image.decode_image(image_str_tensor,
+                                      channels=3,
+                                      dtype=tf.uint8)
+        image = tf.reshape(image, FLAGS.x_feature_shape[1:])
+        return image
+
+    # Run processing for batch prediction.
+    input_ph = tf.compat.v1.placeholder(tf.string, shape=[None], name='image_binary')
+    with tf.device("/cpu:0"):
+        images_tensor = tf.map_fn(decode_and_resize, input_ph, back_prop=False, dtype=tf.uint8)
+
+    # Cast to float
+    images_tensor = tf.cast(images_tensor, dtype=tf.float32)
+
+    # re-scale pixel values between 0 and 1
+    images_tensor = tf.divide(images_tensor, 255)
+
+    return tf.estimator.export.ServingInputReceiver(
+        {FLAGS.x_feature_name: images_tensor},
+        {'image_bytes': input_ph})
+
+
+def main(_):
+    """
+    Function to run TF Estimator
+    Note: set the `TF_CONFIG` environment variable according to:
+    https://www.tensorflow.org/api_docs/python/tf/estimator/train_and_evaluate
+    """
+
+    ###################################
+    # Set parameters/config
+    ###################################
+
+    # Set logging info so it'll be written the command line
+    logging.set_verbosity(logging.INFO)
+
+    os.environ['TF_CONFIG'] = '{}'
+    os.environ['_TF_CONFIG_ENV'] = '{}'
+
+    # Set a bunch of TF config params
+    tf_config = os.environ.get('TF_CONFIG', '{}')
+    logging.info("TF_CONFIG %s", tf_config)
+    tf_config_json = json.loads(tf_config)
+    cluster = tf_config_json.get('cluster')
+    job_name = tf_config_json.get('task', {}).get('type')
+    task_index = tf_config_json.get('task', {}).get('index')
+    logging.info("cluster=%s job_name=%s task_index=%s", cluster, job_name,
+                 task_index)
+
+    is_chief = False
+    if not job_name or job_name.lower() in ["chief", "master"]:
+        is_chief = True
+        logging.info("Will export model.")
+    else:
+        logging.info("Won't export model.")
+
+    print('TF_CONFIG: {}'.format(os.environ['TF_CONFIG']))
+    print('_TF_CONFIG_ENV: {}'.format(os.environ['_TF_CONFIG_ENV']))
+
+    run_config = tf.estimator.RunConfig(model_dir=FLAGS.tf_model_dir + FLAGS.model_id,
+                                        save_summary_steps=FLAGS.tf_steps_per_summary,
+                                        save_checkpoints_steps=FLAGS.tf_steps_per_checkpoint,
+                                        log_step_count_steps=FLAGS.tf_steps_per_summary)
+
+    model_params = {"n_classes": FLAGS.n_classes,
+                    "input_shape": FLAGS.x_feature_shape[1:4],
+                    "train_steps": FLAGS.tf_train_steps,
+                    "dense_size_a": FLAGS.tf_dense_size_a,
+                    "dense_size": FLAGS.tf_dense_size,
+                    "dense_activation": FLAGS.tf_dense_activation,
+                    "dense_dropout_rate_a": FLAGS.tf_dense_dropout_rate_a,
+                    "dense_dropout_rate": FLAGS.tf_dense_dropout_rate,
+                    "optimizer": FLAGS.tf_optimizer,
+                    "metrics": [tf.keras.metrics.Precision(), tf.keras.metrics.Recall(),
+                                FBetaScore(num_classes=2, beta=2.0, average='weighted')],
+                    "learning_rate": FLAGS.tf_learning_rate,
+                    #"loss": sigmoid_focal_crossentropy,
+                    "loss": tf.keras.losses.BinaryCrossentropy(),
+                    "class_names": FLAGS.class_names,
+                    "n_train_samps": FLAGS.n_train_samps,
+                    "n_val_samps": FLAGS.n_val_samps}
+
+    def precision_m(labels, predictions):
+        precision_metric = tf.keras.metrics.Precision(name="precision_m")
+        precision_metric.update_state(y_true=labels, y_pred=predictions['output'])
+        return {"precision_m": precision_metric}
+
+    def recall_m(labels, predictions):
+        recall_metric = tf.keras.metrics.Recall(name="recall_m")
+        recall_metric.update_state(y_true=labels, y_pred=predictions['output'])
+        return {"recall_m": recall_metric}
+
+    def fbeta_m(labels, predictions):
+        fbeta_metric = FBetaScore(num_classes=2, beta=2.0, average='weighted', threshold=.5)
+        fbeta_metric.update_state(y_true=labels, y_pred=predictions['output'])
+        return {"fbeta_m": fbeta_metric}
+
+    classifier = resnet50_estimator(model_params, FLAGS.tf_model_dir, run_config)
+    classifier = tf.estimator.add_metrics(classifier, fbeta_m)
+    classifier = tf.estimator.add_metrics(classifier, precision_m)
+    classifier = tf.estimator.add_metrics(classifier, recall_m)
+
+    ###################################
+    # Check if user wants to run test
+    ###################################
+    # Create test dataset function if needed
+    if FLAGS.tf_test_ckpt_path:
+        print('Overriding training and running test set prediction with model ckpt: {}'.format(
+            FLAGS.tf_test_ckpt_path))
+
+        if not os.path.exists(FLAGS.tf_test_results_dir):
+            os.makedirs(FLAGS.tf_test_results_dir)
+
+        logging.info('Beginning test for model')
+
+        # Create test data function, get `y_true`
+        fpath_test = op.join(FLAGS.tf_test_data_dir, 'test.tfrecords')
+        map_func = partial(parse_fn, n_chan=3,
+                           n_classes=model_params['n_classes'])
+
+        dataset_test = get_dataset_feeder(fpath=fpath_test,
+                                          data_map_func=map_func,
+                                          shuffle_buffer_size=None,
+                                          repeat=False,
+                                          n_map_threads=FLAGS.n_map_threads,
+                                          batch_size=1,  # Use bs=1 here to count samples instead of batches
+                                          cycle_length=FLAGS.cycle_length,
+                                          prefetch_buffer_size=FLAGS.prefetch_buffer_size)
+        y_true = []
+        for features in dataset_test:
+            y_true.append(features[1].numpy()[0])
+        print('Found {} total samples to test.'.format(len(y_true)))
+
+        # Reset the dataset iteration for prediction
+        dataset_test_fn = partial(get_dataset_feeder,
+                                  fpath=fpath_test,
+                                  data_map_func=map_func,
+                                  shuffle_buffer_size=None,
+                                  repeat=False,
+                                  n_map_threads=FLAGS.n_map_threads,
+                                  batch_size=FLAGS.tf_batch_size,
+                                  cycle_length=FLAGS.cycle_length,
+                                  prefetch_buffer_size=FLAGS.prefetch_buffer_size)
+
+        # Reset test iterator and run predictions
+        raw_preds = classifier.predict(dataset_test_fn,
+                                       yield_single_examples=True,
+                                       checkpoint_path=FLAGS.tf_test_ckpt_path)
+
+        p_list = [raw_pred['output'] for raw_pred in raw_preds]
+
+        preds = []
+        for i in tqdm(range(len(p_list)), miniters=1000):
+            a = p_list[i] >= 0.5
+            a = a.astype(int)
+            preds.append(a)
+
+        output_d = {"raw_prediction": p_list,
+                    "threshold": preds,
+                    "true-label": y_true}
+
+        df_pred = pd.DataFrame.from_dict(output_d)
+        df_pred.to_csv(FLAGS.tf_test_results_dir + 'preds.csv') #make into flag
+
+        print('preds csv written')
+
+        recall_lst = []
+        for i in np.arange(0, FLAGS.n_classes):
+            recall_lst.append(recall_score(np.array(y_true)[:, i], np.array(preds)[:, i]))
+
+        precision_lst = []
+        for i in np.arange(0, FLAGS.n_classes):
+            precision_lst.append(precision_score(np.array(y_true)[:, i], np.array(preds)[:, i]))
+
+        f_lst = []
+        for i in np.arange(0, FLAGS.n_classes):
+            f_lst.append(fbeta_score(np.array(y_true)[:, i], np.array(preds)[:, i], beta=2))
+
+        d = {'Precision': precision_lst,
+             'Recall': recall_lst,
+             'fbeta_2': f_lst,
+             'POI': model_params['class_names']}
+
+        df = pd.DataFrame.from_dict(d)
+        df['POI'] = model_params['class_names']
+        df.to_csv(FLAGS.tf_test_results_dir + 'test_stats.csv') #make into flag
+
+        print("test stats written")
+        return d
+
+    ###################################
+    # Create data feeder functions
+    ###################################
+
+    ## download data from GCS
+
+    #list_and_download_blobs(FLAGS.gcs_bucket_name, FLAGS.local_dataset_dirs)
+
+    # Create training dataset function
+    fpath_train = op.join(FLAGS.tf_train_data_dir, 'train_*.tfrecords')
+    map_func = partial(parse_and_augment_fn, n_chan=3,
+                       n_classes=model_params['n_classes'])
+
+    dataset_train_fn = partial(get_dataset_feeder,
+                               fpath=fpath_train,
+                               data_map_func=map_func,
+                               shuffle_buffer_size=FLAGS.shuffle_buffer_size,
+                               repeat=True,
+                               n_map_threads=FLAGS.n_map_threads,
+                               batch_size=FLAGS.tf_batch_size,
+                               cycle_length=FLAGS.cycle_length,
+                               prefetch_buffer_size=FLAGS.prefetch_buffer_size)
+
+    # Create validation dataset function
+    fpath_validate = op.join(FLAGS.tf_val_data_dir, 'val_*.tfrecords')
+    map_func = partial(parse_fn, n_chan=3,
+                       n_classes=model_params['n_classes'])
+
+    dataset_validate_fn = partial(get_dataset_feeder,
+                                  fpath=fpath_validate,
+                                  data_map_func=map_func,
+                                  shuffle_buffer_size=FLAGS.shuffle_buffer_size,
+                                  repeat=True,
+                                  n_map_threads=FLAGS.n_map_threads,
+                                  batch_size=FLAGS.tf_batch_size,
+                                  cycle_length=FLAGS.cycle_length,
+                                  prefetch_buffer_size=FLAGS.prefetch_buffer_size)
+
+    ###################################
+    # Run train/val w/ estimator object
+    ###################################
+
+    # Set up train and evaluation specifications
+    train_spec = tf.estimator.TrainSpec(input_fn=dataset_train_fn,
+                                        max_steps=FLAGS.tf_train_steps)
+
+    logging.info("export final pre")
+    export_final = tf.estimator.FinalExporter(FLAGS.model_id,
+                                              serving_input_receiver_fn=resnet_serving_input_receiver_fn)
+    logging.info("export final post")
+    #
+    eval_spec = tf.estimator.EvalSpec(input_fn=dataset_validate_fn,
+                                      steps=FLAGS.n_val_samps,  # Evaluate until complete
+                                      exporters=export_final,
+                                      throttle_secs=1,
+                                      start_delay_secs=1)
+    logging.info("eval spec")
+
+    ###################################
+    # Run training, save if needed
+    ###################################
+    logging.info("train and evaluate")
+    tf.estimator.train_and_evaluate(classifier, train_spec, eval_spec)
+    logging.info("training done.")
+
+    ############################################################################
+    # Upload checkpoints, tf events, and model exported for evaluation to AWS
+    ############################################################################
+
+#TO-DO
+
+
+if __name__ == '__main__':
+    app.run(main)

--- a/task-retrain/model.py
+++ b/task-retrain/model.py
@@ -8,8 +8,7 @@ import os.path as op
 import json
 import numpy as np
 import pandas as pd
-
-import zipfile
+import shutil
 
 from functools import partial
 
@@ -27,7 +26,6 @@ from tensorflow.keras.optimizers import Adam, SGD, RMSprop
 from utils_train import FBetaScore
 from utils_readtfrecords import parse_and_augment_fn, parse_fn, get_dataset_feeder
 from utils_loss import sigmoid_focal_crossentropy
-import glob
 
 from sklearn.metrics import precision_score, recall_score, fbeta_score
 
@@ -383,6 +381,12 @@ def main(_):
     ############################################################################
     # Upload checkpoints, tf events, and model exported for evaluation to AWS
     ############################################################################
+
+    logging.info("zipping model export")
+
+    #shutil.make_archive('/ml/models/model.zip', 'zip', dir_name)
+
+
 
 #TO-DO
 

--- a/task-retrain/requirements.txt
+++ b/task-retrain/requirements.txt
@@ -1,3 +1,5 @@
 requests==2.24.0
 numpy==1.19.1
 boto3==1.14.20
+tensorflow==2.0.0
+pandas==1.0.5

--- a/task-retrain/utils_loss.py
+++ b/task-retrain/utils_loss.py
@@ -1,0 +1,122 @@
+"""Implements Focal loss."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+import tensorflow.keras.backend as K
+
+
+class SigmoidFocalCrossEntropy(tf.keras.losses.Loss):
+    """Implements the focal loss function.
+    Focal loss was first introduced in the RetinaNet paper
+    (https://arxiv.org/pdf/1708.02002.pdf). Focal loss is extremely useful for
+    classification when you have highly imbalanced classes. It down-weights
+    well-classified examples and focuses on hard examples. The loss value is
+    much high for a sample which is misclassified by the classifier as compared
+    to the loss value corresponding to a well-classified example. One of the
+    best use-cases of focal loss is its usage in object detection where the
+    imbalance between the background class and other classes is extremely high.
+    Usage:
+    ```python
+    fl = tfa.losses.SigmoidFocalCrossEntropy()
+    loss = fl(
+      [[0.97], [0.91], [0.03]],
+      [[1.0], [1.0], [0.0]])
+    print('Loss: ', loss.numpy())  # Loss: [0.00010971,
+                                            0.0032975,
+                                            0.00030611]
+    ```
+    Usage with tf.keras API:
+    ```python
+    model = tf.keras.Model(inputs, outputs)
+    model.compile('sgd', loss=tf.keras.losses.SigmoidFocalCrossEntropy())
+    ```
+    Args
+      alpha: balancing factor, default value is 0.25
+      gamma: modulating factor, default value is 2.0
+    Returns:
+      Weighted loss float `Tensor`. If `reduction` is `NONE`, this has the same
+          shape as `y_true`; otherwise, it is scalar.
+    Raises:
+        ValueError: If the shape of `sample_weight` is invalid or value of
+          `gamma` is less than zero
+    """
+
+    def __init__(self,
+                 from_logits=False,
+                 alpha=0.25,
+                 gamma=2.0,
+                 reduction=tf.keras.losses.Reduction.NONE,
+                 name='sigmoid_focal_crossentropy'):
+        super(SigmoidFocalCrossEntropy, self).__init__(
+            name=name, reduction=reduction)
+
+        self.from_logits = from_logits
+        self.alpha = alpha
+        self.gamma = gamma
+
+    def call(self, y_true, y_pred):
+        return sigmoid_focal_crossentropy(
+            y_true,
+            y_pred,
+            alpha=self.alpha,
+            gamma=self.gamma,
+            from_logits=self.from_logits)
+
+    def get_config(self):
+        config = {
+            "from_logits": self.from_logits,
+            "alpha": self.alpha,
+            "gamma": self.gamma,
+        }
+        base_config = super(SigmoidFocalCrossEntropy, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+@tf.function
+def sigmoid_focal_crossentropy(y_true,
+                               y_pred,
+                               alpha=0.25,
+                               gamma=2.0,
+                               from_logits=False):
+    """
+    Args
+        y_true: true targets tensor.
+        y_pred: predictions tensor.
+        alpha: balancing factor.
+        gamma: modulating factor.
+    Returns:
+        Weighted loss float `Tensor`. If `reduction` is `NONE`,this has the
+        same shape as `y_true`; otherwise, it is scalar.
+    """
+    if gamma and gamma < 0:
+        raise ValueError(
+            "Value of gamma should be greater than or equal to zero")
+
+    y_pred = tf.convert_to_tensor(y_pred)
+    y_true = tf.dtypes.cast(y_true, tf.float32)
+
+    # Get the cross_entropy for each entry
+    ce = K.binary_crossentropy(y_true, y_pred, from_logits=from_logits)
+
+    # If logits are provided then convert the predictions into probabilities
+    if from_logits:
+        pred_prob = tf.sigmoid(y_pred)
+    else:
+        pred_prob = y_pred
+
+    p_t = (y_true * pred_prob) + ((1 - y_true) * (1 - pred_prob))
+    alpha_factor = 1.0
+    modulating_factor = 1.0
+
+    if alpha:
+        alpha = tf.convert_to_tensor(alpha, dtype=K.floatx())
+        alpha_factor = (y_true * alpha + (1 - y_true) * (1 - alpha))
+
+    if gamma:
+        gamma = tf.convert_to_tensor(gamma, dtype=K.floatx())
+        modulating_factor = tf.pow((1.0 - p_t), gamma)
+
+    # compute the final loss and return
+    return tf.reduce_sum(alpha_factor * modulating_factor * ce, axis=-1)

--- a/task-retrain/utils_readtfrecords.py
+++ b/task-retrain/utils_readtfrecords.py
@@ -1,0 +1,108 @@
+import tensorflow as tf
+import os
+
+flags = tf.compat.v1.flags
+FLAGS = flags.FLAGS
+
+def _augment_helper(image):
+    """Augment an image with flipping/brightness changes"""
+    image = tf.image.random_flip_left_right(image)
+    image = tf.image.random_flip_up_down(image)
+    image = tf.image.random_brightness(image, max_delta=0.05)
+    image = tf.image.random_contrast(image, 0, 1)
+    return image
+
+
+def _parse_helper(example, n_chan, n_classes):
+    """"Parse TFExample record containing image and label."""""
+
+    example_fmt = {"image": tf.io.FixedLenFeature([], tf.string),
+                   "label": tf.io.FixedLenFeature([], tf.string)}
+    parsed = tf.io.parse_single_example(example, example_fmt)
+
+    # Get label, decode
+    label = tf.io.parse_tensor(parsed['label'], tf.uint8)
+
+    label = tf.reshape(label, [-1])
+
+    # Get image string, decode
+    image = tf.image.decode_image(parsed['image'])
+    image = tf.reshape(image, [256, 256, 3])
+
+    # change dtype to float32
+    image = tf.cast(image, tf.float32)
+
+    # re-scale pixel values between 0 and 1
+    image = tf.divide(image, 255)
+
+    return image, label
+
+
+def parse_and_augment_fn(example, n_chan=3, n_classes=11):
+    """Parse TFExample record containing image and label and then augment image."""
+    image, label = _parse_helper(example, n_chan, n_classes)
+    #image = preproc(_augment_helper(image))
+    return image, label
+
+
+def parse_fn(example, n_chan=3, n_classes=11):
+    """Parse TFExample record containing image and label."""
+    image, label = _parse_helper(example, n_chan, n_classes)
+    #image = preproc(image)
+    return image, label
+
+
+def make_dataset(path):
+    dataset = tf.data.TFRecordDataset(path)
+    dataset = dataset.shuffle(buffer_size=FLAGS.shuffle_buffer_size)
+    dataset = dataset.map(map_func=parse_fn, num_parallel_calls=tf.data.experimental.AUTOTUNE)
+    dataset = dataset.batch(batch_size=FLAGS.batch_size)
+    dataset = dataset.prefetch(buffer_size=tf.data.experimental.AUTOTUNE)
+    return dataset
+
+def _parse_image_function(example_proto):
+    image_feature_description = {
+        'image': tf.io.FixedLenFeature([], tf.string),
+        'label': tf.io.FixedLenFeature([], tf.string)
+    }
+    return tf.io.parse_single_example(example_proto, image_feature_description)
+
+
+def get_example(tfrecords_path):
+    dataset = tf.data.TFRecordDataset([tfrecords_path])
+
+    parsed_image_dataset = dataset.map(_parse_image_function)
+
+    for image_features in parsed_image_dataset:
+        image_raw = image_features['image'].numpy()
+        img = tf.image.decode_image(image_raw)
+
+        label = image_features['label'].numpy()
+        label = tf.io.parse_tensor(label.numpy(), tf.uint8).numpy()
+    return img, label
+
+
+def get_dataset_feeder(fpath, data_map_func=None, shuffle_buffer_size=None,
+                       repeat=True, n_map_threads=4, batch_size=16,
+                       cycle_length=1, prefetch_buffer_size=None):
+    """Returns a TF Dataset for training/evaluating TF Estimators"""
+
+    files = tf.io.matching_files(os.path.join(fpath))
+    shards = tf.data.Dataset.from_tensor_slices(files)
+    shards = shards.shuffle(buffer_size=4)
+
+    ds = tf.data.TFRecordDataset(shards)
+
+    #TODO: use `shuffle_and_repeat` in v1.13+
+    #ds = ds.shuffle_and_repeat(buffer_size=shuffle_buffer_size)
+    if shuffle_buffer_size:
+        ds = ds.shuffle(shuffle_buffer_size)
+    if repeat:
+        ds = ds.repeat()
+    if data_map_func:
+        ds = ds.map(map_func=data_map_func, num_parallel_calls=n_map_threads)
+    ds = ds.batch(batch_size=batch_size)
+    if prefetch_buffer_size:
+        ds = ds.prefetch(buffer_size=prefetch_buffer_size)
+
+    return ds

--- a/task-retrain/utils_train.py
+++ b/task-retrain/utils_train.py
@@ -1,0 +1,204 @@
+import tensorflow as tf
+from sklearn.metrics import fbeta_score
+
+def fbeta(true_label, prediction):
+    return fbeta_score(true_label, prediction, beta=1, average='samples')
+
+
+class FBetaScore(tf.keras.metrics.Metric):
+    """Computes F-Beta score.
+    It is the weighted harmonic mean of precision
+    and recall. Output range is [0, 1]. Works for
+    both multi-class and multi-label classification.
+    F-Beta = (1 + beta^2) * (prec * recall) / ((beta^2 * prec) + recall)
+    Args:
+        num_classes: Number of unique classes in the dataset.
+        average: Type of averaging to be performed on data.
+            Acceptable values are `None`, `micro`, `macro` and
+            `weighted`. Default value is None.
+        beta: Determines the weight of precision and recall
+            in harmonic mean. Determines the weight given to the
+            precision and recall. Default value is 1.
+        threshold: Elements of `y_pred` greater than threshold are
+            converted to be 1, and the rest 0. If threshold is
+            None, the argmax is converted to 1, and the rest 0.
+    Returns:
+        F-Beta Score: float
+    Raises:
+        ValueError: If the `average` has values other than
+        [None, micro, macro, weighted].
+        ValueError: If the `beta` value is less than or equal
+        to 0.
+    `average` parameter behavior:
+        None: Scores for each class are returned
+        micro: True positivies, false positives and
+            false negatives are computed globally.
+        macro: True positivies, false positives and
+            false negatives are computed for each class
+            and their unweighted mean is returned.
+        weighted: Metrics are computed for each class
+            and returns the mean weighted by the
+            number of true instances in each class.
+    """
+
+    def __init__(self,
+                 num_classes,
+                 average=None,
+                 beta=1.0,
+                 threshold=None,
+                 name='fbeta_score',
+                 dtype=tf.float32):
+        super(FBetaScore, self).__init__(name=name)
+
+        if average not in (None, 'micro', 'macro', 'weighted'):
+            raise ValueError("Unknown average type. Acceptable values "
+                             "are: [None, micro, macro, weighted]")
+
+        if not isinstance(beta, float):
+            raise TypeError("The value of beta should be a python float")
+
+        if beta <= 0.0:
+            raise ValueError("beta value should be greater than zero")
+
+        if threshold is not None:
+            if not isinstance(threshold, float):
+                raise TypeError(
+                    "The value of threshold should be a python float")
+            if threshold > 1.0 or threshold <= 0.0:
+                raise ValueError("threshold should be between 0 and 1")
+
+        self.num_classes = num_classes
+        self.average = average
+        self.beta = beta
+        self.threshold = threshold
+        self.axis = None
+        self.init_shape = []
+
+        if self.average != 'micro':
+            self.axis = 0
+            self.init_shape = [self.num_classes]
+
+        def _zero_wt_init(name):
+            return self.add_weight(
+                name,
+                shape=self.init_shape,
+                initializer='zeros',
+                dtype=self.dtype)
+
+        self.true_positives = _zero_wt_init('true_positives')
+        self.false_positives = _zero_wt_init('false_positives')
+        self.false_negatives = _zero_wt_init('false_negatives')
+        self.weights_intermediate = _zero_wt_init('weights_intermediate')
+
+    # TODO: Add sample_weight support, currently it is
+    # ignored during calculations.
+    def update_state(self, y_true, y_pred, sample_weight=None):
+        if self.threshold is None:
+            threshold = tf.reduce_max(y_pred, axis=-1, keepdims=True)
+            # make sure [0, 0, 0] doesn't become [1, 1, 1]
+            # Use abs(x) > eps, instead of x != 0 to check for zero
+            y_pred = tf.logical_and(y_pred >= threshold,
+                                    tf.abs(y_pred) > 1e-12)
+        else:
+            y_pred = y_pred > self.threshold
+
+        y_true = tf.cast(y_true, tf.int32)
+        y_pred = tf.cast(y_pred, tf.int32)
+
+        def _count_non_zero(val):
+            non_zeros = tf.math.count_nonzero(val, axis=self.axis)
+            return tf.cast(non_zeros, self.dtype)
+
+        self.true_positives.assign_add(_count_non_zero(y_pred * y_true))
+        self.false_positives.assign_add(_count_non_zero(y_pred * (y_true - 1)))
+        self.false_negatives.assign_add(_count_non_zero((y_pred - 1) * y_true))
+        self.weights_intermediate.assign_add(_count_non_zero(y_true))
+
+    def result(self):
+        precision = tf.math.divide_no_nan(
+            self.true_positives, self.true_positives + self.false_positives)
+        recall = tf.math.divide_no_nan(
+            self.true_positives, self.true_positives + self.false_negatives)
+
+        mul_value = precision * recall
+        add_value = (tf.math.square(self.beta) * precision) + recall
+        mean = (tf.math.divide_no_nan(mul_value, add_value))
+        f1_score = mean * (1 + tf.math.square(self.beta))
+
+        if self.average == 'weighted':
+            weights = tf.math.divide_no_nan(
+                self.weights_intermediate,
+                tf.reduce_sum(self.weights_intermediate))
+            f1_score = tf.reduce_sum(f1_score * weights)
+
+        elif self.average is not None:  # [micro, macro]
+            f1_score = tf.reduce_mean(f1_score)
+
+        return f1_score
+
+    def get_config(self):
+        """Returns the serializable config of the metric."""
+
+        config = {
+            "num_classes": self.num_classes,
+            "average": self.average,
+            "beta": self.beta,
+        }
+
+        if self.threshold is not None:
+            config["threshold"] = self.threshold
+
+        base_config = super(FBetaScore, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+    def reset_states(self):
+        self.true_positives.assign(tf.zeros(self.init_shape, self.dtype))
+        self.false_positives.assign(tf.zeros(self.init_shape, self.dtype))
+        self.false_negatives.assign(tf.zeros(self.init_shape, self.dtype))
+        self.weights_intermediate.assign(tf.zeros(self.init_shape, self.dtype))
+
+
+class F1Score(FBetaScore):
+    """Computes F-1 Score.
+    It is the harmonic mean of precision and recall.
+    Output range is [0, 1]. Works for both multi-class
+    and multi-label classification.
+    F-1 = 2 * (precision * recall) / (precision + recall)
+    Args:
+        num_classes: Number of unique classes in the dataset.
+        average: Type of averaging to be performed on data.
+            Acceptable values are `None`, `micro`, `macro`
+            and `weighted`. Default value is None.
+        threshold: Elements of `y_pred` above threshold are
+            considered to be 1, and the rest 0. If threshold is
+            None, the argmax is converted to 1, and the rest 0.
+    Returns:
+        F-1 Score: float
+    Raises:
+        ValueError: If the `average` has values other than
+        [None, micro, macro, weighted].
+    `average` parameter behavior:
+        None: Scores for each class are returned
+        micro: True positivies, false positives and
+            false negatives are computed globally.
+        macro: True positivies, false positives and
+            false negatives are computed for each class
+            and their unweighted mean is returned.
+        weighted: Metrics are computed for each class
+            and returns the mean weighted by the
+            number of true instances in each class.
+    """
+
+    def __init__(self,
+                 num_classes,
+                 average=None,
+                 threshold=None,
+                 name='f1_score',
+                 dtype=tf.float32):
+        super(F1Score, self).__init__(
+            num_classes, average, 1.0, threshold, name=name, dtype=dtype)
+
+    def get_config(self):
+        base_config = super(F1Score, self).get_config()
+        del base_config["beta"]
+        return base_config


### PR DESCRIPTION
Still very much a WIP but opening PR so it's easier for you to track cc @ingalls 

- model training assumes that the necessary tf-records files are already inside the docker container in `/ml/models/` 
- model training checkpoints and final output in the format ready for TF-Serving are just written to the docker container and not pushed to an S3 bucket yet 

To-Dos: 

- [ ] in general clean up code 
- [ ] add option to re-train from checkpoint vs training from scratch (current implementation) 
- [ ] modify `model.py` code to run as a callable function with arguments instead of cli with flags 
- [ ] option to overwrite default arguments with information from ml-enabler data base (ie num classes, class names ect)
- [ ] modify `task.py` to call the `model.py` script (reminder need to use `nvidia docker` to run w/ GPU)
- [ ] after training is complete create a zip file of the best checkpoint files to upload to S3 
- [ ] after training is complete zip up the export file that contains (`.pb` and `variables` file) 
- [ ] UI components 
