### PR TITLE
Only show archived when toggled

### DIFF
--- a/web/src/components/Home.vue
+++ b/web/src/components/Home.vue
@@ -30,7 +30,7 @@
             </template>
             <template v-else>
                 <div @click='$router.push({ name: "model", params: { modelid: model.modelId } })' :key='model.modelId' v-for='model in models'>
-                    <template v-if='!model.archived || archived'>
+                    <template v-if='(archived && model.archived) || (!archived && !model.archived)'>
                         <div class='cursor-pointer bg-darken10-on-hover col col--12 py12'>
                             <div class='col col--12 grid py6 px12'>
                                 <div class='col col--6'>


### PR DESCRIPTION
### Context

When the user clicks the "Archived Models" toggle, only archived models should be shown. Currently they appear randomly scattered amongst existing models

### Actions

- [x] When `archived model` toggle is used, only show archived models (hide active models)

cc/ @martham93 

Closes: https://github.com/developmentseed/ml-enabler/issues/48