### PR TITLE
Use window.api

### DIFF
--- a/web/src/components/Login.vue
+++ b/web/src/components/Login.vue
@@ -58,7 +58,7 @@ export default {
             if (!this.password.length) return;
             this.loading = true;
 
-            fetch(window.location.origin + `/v1/user/login`, {
+            fetch(window.api + `/v1/user/login`, {
                 method: 'post',
                 headers: {
                     'Content-Type': 'application/json'


### PR DESCRIPTION
### Context

Login could fail under certain deployment conditions if the API was hosted under a sub path.

cc/ @martham93 