### PR TITLE
Add full breadcrumb

### DIFF
--- a/web/src/components/Prediction.vue
+++ b/web/src/components/Prediction.vue
@@ -1,7 +1,11 @@
 <template>
     <div class="col col--12">
         <div class='col col--12 clearfix py6'>
-            <h2 class='fl cursor-default' v-text='"Prediction: " + prediction.versionString'></h2>
+            <h2 @click='$router.push({ name: "home" })' class='fl cursor-pointer txt-underline-on-hover'>Models</h2>
+            <h2 class='fl px6'>&gt;</h2>
+            <h2 @click='$router.push({ name: "model", params: { modelid: $route.params.modelid } })' class='fl cursor-pointer txt-underline-on-hover' v-text='$route.params.modelid'></h2>
+            <h2 class='fl px6'>&gt;</h2>
+            <h2 class='fl cursor-default cursor-pointer txt-underline-on-hover' v-text='"v" + prediction.version'></h2>
 
             <button @click='$router.push({ name: "model", params: { modelid: $route.params.modelid } })' class='btn fr round btn--stroke color-gray color-black-on-hover'>
                 <svg class='icon'><use href='#icon-close'/></svg>


### PR DESCRIPTION
### Context

Models => Model has breadcrumb support, the prediction page should continue to use this norm:

#### Actions:

- [x] Update Prediction Component to use breadcrump as title

![Screenshot from 2020-07-23 14-06-18](https://user-images.githubusercontent.com/1297009/88338821-cbfea480-cced-11ea-88a1-d83e6d85b522.png)

vs.

![Screenshot from 2020-07-23 14-07-23](https://user-images.githubusercontent.com/1297009/88338858-da4cc080-cced-11ea-8c4c-85f2b24a9794.png)

Example of Fix:

```
Models > Alpha Retrain > v1.0.0

or

Models > 12 > v1.0.0
```

cc/ @martham93 

Ref: https://github.com/developmentseed/ml-enabler/issues/47