### PR TITLE
NPZ export fixes 

### DIFF
--- a/ml_enabler/api/ml.py
+++ b/ml_enabler/api/ml.py
@@ -401,7 +401,6 @@ class PredictionExport(Resource):
 
         def generate_npz():
             labels_dict ={}
-            print(labels_dict)
             for row in stream:
                 if req_inferences != 'all' and row[3].get(req_inferences) is None:
                     continue

--- a/ml_enabler/api/ml.py
+++ b/ml_enabler/api/ml.py
@@ -385,7 +385,7 @@ class PredictionExport(Resource):
     def get(self, model_id, prediction_id):
         req_format = request.args.get('format', 'geojson')
         req_inferences = request.args.get('inferences', 'all')
-        req_threshold = request.args.get('threshold', '0.0')
+        req_threshold = request.args.get('threshold', '0')
 
         req_threshold = float(req_threshold)
         stream = PredictionService.export(prediction_id)

--- a/ml_enabler/api/ml.py
+++ b/ml_enabler/api/ml.py
@@ -414,7 +414,7 @@ class PredictionExport(Resource):
                     for num, inference in enumerate(i_lst):
                         raw_pred.append(row[3][inference])
                     if  req_inferences == 'all':
-                        req_threshold = 0.5 
+                        req_threshold = request.args.get('threshold', '0.5')
                     l = [1 if score >= req_threshold else 0 for score in raw_pred]
 
                     #convert quadkey to x-y-z

--- a/ml_enabler/api/ml.py
+++ b/ml_enabler/api/ml.py
@@ -385,7 +385,7 @@ class PredictionExport(Resource):
     def get(self, model_id, prediction_id):
         req_format = request.args.get('format', 'geojson')
         req_inferences = request.args.get('inferences', 'all')
-        req_threshold = request.args.get('threshold', '0.5')
+        req_threshold = request.args.get('threshold', '0.0')
 
         req_threshold = float(req_threshold)
         stream = PredictionService.export(prediction_id)
@@ -413,6 +413,8 @@ class PredictionExport(Resource):
                     raw_pred = []
                     for num, inference in enumerate(i_lst):
                         raw_pred.append(row[3][inference])
+                    if  req_inferences == 'all':
+                        req_threshold = 0.5 
                     l = [1 if score >= req_threshold else 0 for score in raw_pred]
 
                     #convert quadkey to x-y-z

--- a/ml_enabler/api/ml.py
+++ b/ml_enabler/api/ml.py
@@ -21,6 +21,14 @@ from sqlalchemy.exc import IntegrityError
 from flask_login import login_required
 import numpy as np
 
+import logging
+from flask import Flask
+app = Flask(__name__)
+gunicorn_logger = logging.getLogger('gunicorn.error')
+app.logger.handlers = gunicorn_logger.handlers
+
+
+
 
 class MetaAPI(Resource):
 
@@ -377,7 +385,7 @@ class PredictionExport(Resource):
     def get(self, model_id, prediction_id):
         req_format = request.args.get('format', 'geojson')
         req_inferences = request.args.get('inferences', 'all')
-        req_threshold = request.args.get('threshold', '0')
+        req_threshold = request.args.get('threshold', '0.5')
 
         req_threshold = float(req_threshold)
         stream = PredictionService.export(prediction_id)

--- a/ml_enabler/api/ml.py
+++ b/ml_enabler/api/ml.py
@@ -401,6 +401,7 @@ class PredictionExport(Resource):
 
         def generate_npz():
             labels_dict ={}
+            print(labels_dict)
             for row in stream:
                 if req_inferences != 'all' and row[3].get(req_inferences) is None:
                     continue
@@ -410,7 +411,9 @@ class PredictionExport(Resource):
                     i_lst = pred.inf_list.split(",")
 
                     #convert raw predictions into 0 or 1 based on threshold
-                    raw_pred = [row[3][i_lst[0]], row[3][i_lst[1]]]
+                    raw_pred = []
+                    for num, inference in enumerate(i_lst):
+                        raw_pred.append(row[3][inference])
                     l = [1 if score >= req_threshold else 0 for score in raw_pred]
 
                     #convert quadkey to x-y-z
@@ -437,7 +440,7 @@ class PredictionExport(Resource):
                                     l[i] = 1
                                 else:
                                     l[i] = 0
-                        labels_dict.update({t:l})
+                            labels_dict.update({t:l})
             if not labels_dict:
                 raise NoValid
 


### PR DESCRIPTION
npz 🐛 removal! 

* This PR addresses the bug in issue #63 , when `all` classes were exported as npz previously the values became `[1, 1]` because the threshold was set to 0 instead of .5. The threshold value default is now at .5 when export type is npz, and when `all` classes are selected. 

* In addition This PR also fixes how the raw prediction value list is created to better support multi-label npz export 


cc @ingalls 