### PR TITLE
la croix color theme for mapped preds

### DIFF
--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -128,9 +128,9 @@
                 </div>
         </div>
         <div class='grid txt-xs align-center'>
-            <div class='col col--4 wmin24'>Unvalidated</div>
-            <div class='col col--4 wmin24'>Validated<br>True</div>
-            <div class='col col--4 wmin24'>Validated <br>False</div>
+            <div class='col col--4'>Unvalidated</div>
+            <div class='col col--4'>Validated<br>True</div>
+            <div class='col col--4'>Validated <br>False</div>
         </div>
     </div>
 </div>

--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -336,11 +336,11 @@ export default {
                     paint: {
                         'fill-color': [
                             'case',
-                            ['==', ["feature-state", `v_${inf}`], false], '#ffffff',
-                            ['==', ["feature-state", `v_${inf}`], true], '#00ff00',
+                            ['==', ["feature-state", `v_${inf}`], false], '#ec747e',
+                            ['==', ["feature-state", `v_${inf}`], true], '#00b6b0',
                             ['==', ['get', `v_${inf}`], false], '#ffffff',
-                            ['==', ['get', `v_${inf}`], true], '#00ff00',
-                            '#ff0000'
+                            ['==', ['get', `v_${inf}`], true], '#ec747e',
+                            '#f9ce99'
                         ],
                         'fill-opacity': [
                             'number',

--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -1,12 +1,31 @@
 <template>
     <div class='col col--12'>
         <div class='col col--12 border-b border--gray-light clearfix mb6'>
-            <PredictionHeader/>
+            <PredictionHeader/>         
 
             <div class='fr'>
                 <button @click='$emit("refresh")' class='mx3 btn btn--stroke color-gray color-blue-on-hover round'><svg class='icon fl'><use href='#icon-refresh'/></svg></button>
             </div>
         </div>
+
+<div class='w240 round shadow-darken10 px12 py12 txt-s'>
+  <div class='flex-parent flex-parent--center-main flex-parent--center-cross align-center'>
+    <div class='flex-child flex-child--grow wmin24'>
+      <span class='inline-block w12 h12 round-full bg-gray-light'></span>
+    </div>
+    <div class='flex-child flex-child--grow wmin24'>
+      <span class='inline-block w12 h12 round-full bg-blue-light'></span>
+    </div>
+    <div class='flex-child flex-child--grow wmin24'>
+      <span class='inline-block w12 h12 round-full bg-pink-light'></span>
+    </div>
+  </div>
+  <div class='grid txt-xs align-center'>
+    <div class='col col--4 wmin24'>Unvalidated</div>
+    <div class='col col--4 wmin24'>Validated and True</div>
+    <div class='col col--4 wmin24'>Validated and False</div>
+  </div>
+</div>
 
         <template v-if='tilejson'>
             <div class='align-center pb6'>Prediction Tiles</div>

--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -338,9 +338,9 @@ export default {
                             'case',
                             ['==', ["feature-state", `v_${inf}`], false], '#ec747e',
                             ['==', ["feature-state", `v_${inf}`], true], '#00b6b0',
-                            ['==', ['get', `v_${inf}`], false], '#ffffff',
+                            ['==', ['get', `v_${inf}`], false], '#ec747e',
                             ['==', ['get', `v_${inf}`], true], '#ec747e',
-                            '#f9ce99'
+                            '#ffffff'
                         ],
                         'fill-opacity': [
                             'number',

--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -115,23 +115,23 @@
         </template>
         <div class='flex-parent flex-parent--center-main my18'>
             <div class='w240 round shadow-darken10 px12 py12 txt-s'>
-            <div class='flex-parent flex-parent--center-main flex-parent--center-cross align-center'>
-                <div class='flex-child flex-child--grow wmin24'>
-                    <span class='inline-block w12 h12 round-full bg-gray-light'></span>
-                </div>
-                <div class='flex-child flex-child--grow wmin24'>
-                    <span class='inline-block w12 h12 round-full bg-blue-light'></span>
-                </div>
-                <div class='flex-child flex-child--grow wmin24'>
-                    <span class='inline-block w12 h12 round-full bg-pink-light'></span>
-                </div>
+                <div class='flex-parent flex-parent--center-main flex-parent--center-cross align-center'>
+                    <div class='flex-child flex-child--grow wmin24'>
+                        <span class='inline-block w12 h12 round-full bg-gray-light'></span>
+                    </div>
+                    <div class='flex-child flex-child--grow wmin24'>
+                        <span class='inline-block w12 h12 round-full bg-blue-light'></span>
+                    </div>
+                    <div class='flex-child flex-child--grow wmin24'>
+                        <span class='inline-block w12 h12 round-full bg-pink-light'></span>
+                    </div>
+            </div>
+            <div class='grid txt-xs align-center'>
+                <div class='col col--4'>Unvalidated</div>
+                <div class='col col--4'>Validated<br>True</div>
+                <div class='col col--4'>Validated <br>False</div>
+            </div>
         </div>
-        <div class='grid txt-xs align-center'>
-            <div class='col col--4'>Unvalidated</div>
-            <div class='col col--4'>Validated<br>True</div>
-            <div class='col col--4'>Validated <br>False</div>
-        </div>
-    </div>
 </div>
     </div>
 </template>

--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -2,12 +2,10 @@
     <div class='col col--12'>
         <div class='col col--12 border-b border--gray-light clearfix mb6'>
             <PredictionHeader/>         
-
             <div class='fr'>
                 <button @click='$emit("refresh")' class='mx3 btn btn--stroke color-gray color-blue-on-hover round'><svg class='icon fl'><use href='#icon-refresh'/></svg></button>
             </div>
         </div>
-
         <template v-if='tilejson'>
             <div class='align-center pb6'>Prediction Tiles</div>
 
@@ -47,7 +45,6 @@
                                     <input v-on:input='opacity = parseInt($event.target.value)' type='range' min=0 max=100 />
                                 </div>
                             </div>
-
                             <div class='col col--12'>
                                 <label>Threshold (<span v-text='threshold'/>%)</label>
                                 <div class='range range--s color-gray'>
@@ -116,27 +113,26 @@
                 </div>
             </div>
         </template>
-
-        <div class='my18'></div>
-        <div class='flex-parent flex-parent--center-main'>
-        <div class='w240 round shadow-darken10 px12 py12 txt-s'>
-        <div class='flex-parent flex-parent--center-main flex-parent--center-cross align-center'>
-            <div class='flex-child flex-child--grow wmin24'>
-            <span class='inline-block w12 h12 round-full bg-gray-light'></span>
-            </div>
-            <div class='flex-child flex-child--grow wmin24'>
-            <span class='inline-block w12 h12 round-full bg-blue-light'></span>
-            </div>
-            <div class='flex-child flex-child--grow wmin24'>
-            <span class='inline-block w12 h12 round-full bg-pink-light'></span>
-            </div>
+        <!-- <div class='my18'></div> -->
+        <div class='flex-parent flex-parent--center-main my18'>
+            <div class='w240 round shadow-darken10 px12 py12 txt-s'>
+            <div class='flex-parent flex-parent--center-main flex-parent--center-cross align-center'>
+                <div class='flex-child flex-child--grow wmin24'>
+                    <span class='inline-block w12 h12 round-full bg-gray-light'></span>
+                </div>
+                <div class='flex-child flex-child--grow wmin24'>
+                    <span class='inline-block w12 h12 round-full bg-blue-light'></span>
+                </div>
+                <div class='flex-child flex-child--grow wmin24'>
+                    <span class='inline-block w12 h12 round-full bg-pink-light'></span>
+                </div>
         </div>
         <div class='grid txt-xs align-center'>
             <div class='col col--4 wmin24'>Unvalidated</div>
             <div class='col col--4 wmin24'>Validated<br>True</div>
             <div class='col col--4 wmin24'>Validated <br>False</div>
         </div>
-        </div>
+    </div>
 </div>
     </div>
 </template>

--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -8,25 +8,6 @@
             </div>
         </div>
 
-<div class='w240 round shadow-darken10 px12 py12 txt-s'>
-  <div class='flex-parent flex-parent--center-main flex-parent--center-cross align-center'>
-    <div class='flex-child flex-child--grow wmin24'>
-      <span class='inline-block w12 h12 round-full bg-gray-light'></span>
-    </div>
-    <div class='flex-child flex-child--grow wmin24'>
-      <span class='inline-block w12 h12 round-full bg-blue-light'></span>
-    </div>
-    <div class='flex-child flex-child--grow wmin24'>
-      <span class='inline-block w12 h12 round-full bg-pink-light'></span>
-    </div>
-  </div>
-  <div class='grid txt-xs align-center'>
-    <div class='col col--4 wmin24'>Unvalidated</div>
-    <div class='col col--4 wmin24'>Validated<br>True</div>
-    <div class='col col--4 wmin24'>Validated <br>False</div>
-  </div>
-</div>
-
         <template v-if='tilejson'>
             <div class='align-center pb6'>Prediction Tiles</div>
 
@@ -135,6 +116,28 @@
                 </div>
             </div>
         </template>
+
+        <div class='my18'></div>
+        <div class='flex-parent flex-parent--center-main'>
+        <div class='w240 round shadow-darken10 px12 py12 txt-s'>
+        <div class='flex-parent flex-parent--center-main flex-parent--center-cross align-center'>
+            <div class='flex-child flex-child--grow wmin24'>
+            <span class='inline-block w12 h12 round-full bg-gray-light'></span>
+            </div>
+            <div class='flex-child flex-child--grow wmin24'>
+            <span class='inline-block w12 h12 round-full bg-blue-light'></span>
+            </div>
+            <div class='flex-child flex-child--grow wmin24'>
+            <span class='inline-block w12 h12 round-full bg-pink-light'></span>
+            </div>
+        </div>
+        <div class='grid txt-xs align-center'>
+            <div class='col col--4 wmin24'>Unvalidated</div>
+            <div class='col col--4 wmin24'>Validated<br>True</div>
+            <div class='col col--4 wmin24'>Validated <br>False</div>
+        </div>
+        </div>
+</div>
     </div>
 </template>
 
@@ -454,3 +457,4 @@ export default {
     }
 }
 </script>
+

--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -22,8 +22,8 @@
   </div>
   <div class='grid txt-xs align-center'>
     <div class='col col--4 wmin24'>Unvalidated</div>
-    <div class='col col--4 wmin24'>Validated and True</div>
-    <div class='col col--4 wmin24'>Validated and False</div>
+    <div class='col col--4 wmin24'>Validated<br>True</div>
+    <div class='col col--4 wmin24'>Validated <br>False</div>
   </div>
 </div>
 

--- a/web/src/components/prediction/Map.vue
+++ b/web/src/components/prediction/Map.vue
@@ -113,7 +113,6 @@
                 </div>
             </div>
         </template>
-        <!-- <div class='my18'></div> -->
         <div class='flex-parent flex-parent--center-main my18'>
             <div class='w240 round shadow-darken10 px12 py12 txt-s'>
             <div class='flex-parent flex-parent--center-main flex-parent--center-cross align-center'>


### PR DESCRIPTION
addresses issue #64 

- [x] change color 
- [x] add legend 

thoughts on these colors 

the tan for unvalidated predictions, the blue for validated and true, salmon for validated and false? 
<img width="489" alt="Screen Shot 2020-08-13 at 9 53 23 PM" src="https://user-images.githubusercontent.com/13889100/90212138-cb6aa280-ddaf-11ea-83b6-ca7506f2dc4f.png">

taking from the [paplemousse la croix color theme ](https://github.com/johannesbjork/LaCroixColoR)

cc @ingalls 